### PR TITLE
Big bed track

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,18 +19,18 @@ GISAID metadata file, Nextrain parsimony file and VCF file; for -track option, a
 
 ### Options:
 
-`-b T`                 Program will also flag borderline suspicious variants that exhibit low minor allele frequency and are                          significantly associated with 1 or more particular lab.
+**-b T**:            Program will also flag borderline suspicious variants that exhibit low minor allele frequency and are significantly associated with 1 or more particular lab.
 
-`-include T`           Snps with parsimony > min will be included in the output regardless of flags
+**-include T**:      Snps with parsimony > min will be included in the output regardless of flags
 
-`-track`               Program will output a track annotating highly suspect lab associated mutations and a track annotating                          Artic primers that overlap or are within 10bp of lab-associated mutations.
+**-track**:          Program will output a track annotating highly suspect lab associated mutations and a track annotating                          Artic primers that overlap or are within 10bp of lab-associated mutations.
                      See [Viewing tracks in the UCSC Genome Browser](#viewing-tracks-in-the-UCSC-Genome-Browser) below for instructions.
                      The file "primers.txt" (available in this repository) must be present in the current working directory.
 
-`-min_parsimony *I*`    Minimum parsimony (must be an integer) default = 4 (Beware that reducing this parameter from the default
+**-min_parsimony *I***: Minimum parsimony (must be an integer) default = 4 (Beware that reducing this parameter from the default
                      can obscure accuracy)
 
-`-min_contribution *N*` Minimum percent of alternate alleles contributed by a
+**-min_contribution *N***: Minimum percent of alternate alleles contributed by a
                      specific lab for variants to be considered highly
                      suspect; default = 80 (beware that reducing this
                      parameter from the default can obscure accuracy)

--- a/README.md
+++ b/README.md
@@ -5,84 +5,116 @@ We also added a GISAID metadata filter, which filters errors in "submitting lab"
 
 ##########################################
 
-Lab Specific Bias Filter Usage:
+## Lab Specific Bias Filter Usage:
 
 Make sure that parsimony_per_site_analysis.py and sequenceAnalyzer.py are in the same directory. We provide the files we used when running the program.
 
+```
 python3 parsimony_per_site_analysis2.py [options] -m [Path to GISAID metadata file] -p [Path to Nextrain parsimony file] -v [Path to VCF file] -o [Path to output directory]
+```
 
-Input:
+### Input:
 
-GISAID metadata file, Nextrain parsimony file and VCF file
+GISAID metadata file, Nextrain parsimony file and VCF file; for -track option, also primers.txt.
 
-Options:
+### Options:
 
--b                   Program will also flag borderline suspicious variants that exhibit low minor allele frequency and are                          significantly assosiated with 1 or more particular lab.
+`-b T`                 Program will also flag borderline suspicious variants that exhibit low minor allele frequency and are                          significantly associated with 1 or more particular lab.
 
--include             Snps with parsimony > min will be included in the output regardless of flags
+`-include T`           Snps with parsimony > min will be included in the output regardless of flags
 
--track               Program will output a track annotating highly suspect lab assosiated mutations and a track annotating                          Artic primers that overlap or are within 10bp of lab-associated mutations in BED Detail format. Both                          tracks can be directly uploaded to the UCSC Genome Browser. The user must also download "primers.txt"                          (available in this repository) and store it in the current working directory.
+`-track`               Program will output a track annotating highly suspect lab associated mutations and a track annotating                          Artic primers that overlap or are within 10bp of lab-associated mutations.
+                     See [Viewing tracks in the UCSC Genome Browser](#viewing-tracks-in-the-UCSC-Genome-Browser) below for instructions.
+                     The file "primers.txt" (available in this repository) must be present in the current working directory.
 
--min_parsimony       Minimum parsimony (must be an integer) default = 4 (Beware that reducing this parameter from the default
+`-min_parsimony *I*`    Minimum parsimony (must be an integer) default = 4 (Beware that reducing this parameter from the default
                      can obscure accuracy)
 
--min_contribution    Minimum percent of alternate alleles contributed by a
+`-min_contribution *N*` Minimum percent of alternate alleles contributed by a
                      specific lab for variants to be considered highly
                      suspect; default = 80 (beware that reducing this
                      parameter from the default can obscure accuracy)
 
-Output:
+### Output:
 
-flagged_snps_by_lab.tsv    A tab delimitted file displaying bin, source, lab, snp, ref, alt, global ref, global alt, fisher                              exact, proportion of calls, MAF for each flagged snp where:
+**flagged_snps_by_lab.tsv**:    A tab delimitted file displaying bin, source, lab, snp, ref, alt, global ref, global alt, fisher                              exact, proportion of calls, MAF for each flagged snp where:
 
-bin = "highly suspect", "suspect," or "no flag" 
+| Column | Description |
+| ------ | ----------- |
+| bin | "highly suspect", "suspect," or "no flag"  |
+| source | "originating lab" or "submitting lab" |
+| lab | lab name |
+| snp | snp |
+| ref | reference allele count |
+| alt | alternate allele count |
+| global ref | global reference allele count |
+| global alt | global alternate allele count |
+| fisher exact | p value for fishers exact test associating lab specific with global allele frequency |
+| proportion of calls | proportion of minor allele calls attributed to respective lab |
+| MAF | minor allele frequency |
 
-source = "originating lab" or "submitting lab"
+**flagged_snps_summary.tsv**:   A tab delimitted file displaying each flagged snp, bin and the reasoning underlying the flag
 
-lab = lab name
+If the -track option is added:
 
-snp = snp
+**lab_associated_error_final.bedDetail**: A [bedDetail](https://genome.ucsc.edu/FAQ/FAQformat.html#format1.7) file annotating lab-associated mutations.  Contents can be pasted directly into the UCSC Genome Browser as a custom track.
 
-ref = reference allele count
+**Artic_primers_final.bed**: A [BED](https://genome.ucsc.edu/FAQ/FAQformat.html#format1) custom track file annotating Artic Primers.  Contents can be pasted directly into the UCSC Genome Browser as a custom track.
 
-alt = alternate allele count
-
-global ref = global reference allele count
-
-global alt = global alternate allele count
-
-fisher exact = p value for fishers exact test assosiating lab specific with global allele frequency
-
-proportion of calls = proportion of minor allele calls attributed to respective lab
-
-MAF = minor allele frequency
-
-flagged_snps_summary.tsv   A tab delimitted file displaying each flagged snp, bin and the reasoning underlying the flag
-
-lab_associated_error_final.bed     A BED Detail file annotating lab-associated mutations compatable with the UCSC Genome                                        Browser
-
-Artic_primers_final.bed     A BED Detail file annotating Artic Primers compatable with the UCSC Genome Browser
+**lab_associated_error_final.bedForBigBed**:     A [BED](https://genome.ucsc.edu/FAQ/FAQformat.html#format1) file with extra data columns fully annotating lab-associated mutations.  Can be converted to [bigBed](https://genome.ucsc.edu/goldenPath/help/bigBed.html) format for viewing in the UCSC Genome Browser.
 
 ##########################################
 
-GISAID metadata filter Usage:
+## Viewing tracks in the UCSC Genome Browser
+
+If you ran parsimony_per_site_analysis2.py with the `-track` option, then the script generated three extra output files suitable for viewing in the UCSC Genome Browser: lab_associated_error_final.bedDetail, Artic_primers_final.bed, and lab_associated_error_final.bedForBigBed.
+
+The contents of lab_associated_error_final.bedDetail and Artic_primers_final.bed can be copy-pasted directly into the UCSC Genome Browser's [Custom Track](https://genome.ucsc.edu/cgi-bin/hgCustom) input form.
+
+lab_associated_error_final.bedForBigBed has additional columns for a more complete set of annotation details to be displayed when you click on an error in the UCSC Genome Browser, but first it must be converted to the [bigBed](https://genome.ucsc.edu/goldenPath/help/bigBed.html) format as follows.
+
+* Download the [linux](http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/bedToBigBed) or [Mac OS X](http://hgdownload.soe.ucsc.edu/admin/exe/macOSX.x86_64/bedToBigBed) version of `bedToBigBed` program, depending on your computer's platform.  After downloading, you may need to make the file executable using the command `chmod a+x bedToBigBed`.
+
+* Run bedToBigBed like this (the labAssocMuts.as file is included in this repository):
+
+```
+./bedToBigBed -type=bed4+5 -as=labAssocMuts.as -tab lab_associated_error_final.bedForBigBed http://hgdownload.soe.ucsc.edu/goldenPath/wuhCor1/bigZips/wuhCor1.chrom.sizes lab_associated_error_final.bb
+```
+
+* Place the resulting file `lab_associated_error_final.bb` on a website or FTP server (see UCSC's suggestions for [hosting](https://genome.ucsc.edu/goldenPath/help/hgTrackHubHelp.html#Hosting)).
+
+* Copy and paste the following custom track definition line into the UCSC Genome Browser's [Custom Track](https://genome.ucsc.edu/cgi-bin/hgCustom) input form, but replace the example link `http://mylab.org/lab_associated_error_final.bb` with the actual link to lab_associated_error_final.bb on your web/FTP server:
+
+```
+track name=lab_associated_errors description="Lab-associated Mutations" type=bigBed mouseOverField=comment visibility=pack bigDataUrl=http://mylab.org/lab_associated_error_final.bb"
+```
+
+##########################################
+
+## GISAID metadata filter Usage:
 
 We provide our metadata_1_merged.tsv output along with the our log file when we used metadata_1.tsv as input. We hand checked the log file by hand to ensure accuracy and commented out merger errors.
 
+```
 python3 meta_data_filter.py [options] -m [Path to GISAID metadata file] -o [Path to output directory]
+```
 
-Input:
+### Input:
 
 GISAID metadata file
 
-Options:
+### Options:
 
 -c     If "TRUE" only merge high confidence errors.
 
-Output:
+### Output:
 
-metadata_filter.log     Log of changes made to the metadata set and warnings if any changes are made with lower confidence
+**metadata_filter.log**:     Log of changes made to the metadata set and warnings if any changes are made with lower confidence
 
-metadata_merged.tsv     Merged metadata file
+**metadata_merged.tsv**:     Merged metadata file
 
 
+##########################################
+
+### Reference
+* Yatish Turakhia, Bryan Thornlow, Landen Gozashti, Angie S. Hinrichs, Jason D. Fernandes, David Haussler, and Russell Corbett-Detig, "Stability of SARS-CoV-2 Phylogenies", bioRxiv [pre-print](https://www.biorxiv.org/content/10.1101/2020.06.08.141127v1) 2020.

--- a/labAssocMuts.as
+++ b/labAssocMuts.as
@@ -1,0 +1,13 @@
+table labAssocMuts
+"Lab-associated mutations identified using https://github.com/lgozasht/COVID-19-Lab-Specific-Bias-Filter"
+    (
+    string chrom;       "Reference sequence chromosome or scaffold"
+    uint   chromStart;  "Start position in chromosome"
+    uint   chromEnd;    "End position in chromosome"
+    string name;        "Mutation name"
+    int parsimony;      "Number of base value changes in most parsimonious labeling of tree"
+    int altAlleleCount; "Alternate allele count"
+    float maf;          "Minor Allele Frequency"
+    string articPrimer; "ARTIC primer(s) within 10bp of mutation, if applicable"
+    string comment;     "Explanation for inclusion in lab-associated category"
+    )

--- a/parsimony_per_site_analysis2.py
+++ b/parsimony_per_site_analysis2.py
@@ -321,8 +321,14 @@ if args['track'] != None:
         for line in sorted:
             lineList.append(line)
 
-    with open('{0}/lab_associated_error_final.bed'.format(args['o']),'w') as final:
-        final.write('browser position NC_045512v2:0-29903\ntrack name=lab type=bedDetail description="Lab-associated Mutations"\n#chrom\tchromStart\tchromStop\tname\tparsimony score\tnumber of alt alleles\tPrimer within 10bp\tcomment\n')
+    with open('{0}/lab_associated_error_final.bedDetail'.format(args['o']),'w') as final:
+        final.write('browser position NC_045512v2:0-29903\ntrack name=lab type=bedDetail description="Lab-associated Mutations" visibility=pack\n#chrom\tchromStart\tchromStop\tname\tparsimony score\tnumber of alt alleles\tminor allele frequency\tPrimer within 10bp\tcomment\n')
+        for line in lineList:
+            cols = line.split("\t")
+            bedDetailCols = cols[0:4] + [cols[3]] + [cols[8]]
+            final.write('\t'.join(bedDetailCols))
+
+    with open('{0}/lab_associated_error_final.bedForBigBed'.format(args['o']),'w') as final:
         for line in lineList:
             final.write(line)
 
@@ -333,7 +339,7 @@ if args['track'] != None:
         for line in sorted:
             lineList.append(line)
     with open('{0}/Artic_primers_final.bed'.format(args['o']),'w') as final:
-        final.write('browser position NC_045512v2:0-29903\ntrack name=lab type=bedDetail description="Artic Primers"\n#chrom\tchromStart\tchromStop\tname\n')
+        final.write('browser position NC_045512v2:0-29903\ntrack name=primers type=bed description="Artic Primers" visibility=pack\n#chrom\tchromStart\tchromStop\tname\n')
         for line in lineList:
             final.write(line)
     os.system('rm -r {0}/Artic_primers_sorted.bed'.format(args['o']))


### PR DESCRIPTION
This adds the autoSql file labAssocMuts.as and instructions for using bedToBigBed with that file to make a custom track for the UCSC Genome Browser with the full set of output columns (bedDetail adds only an alternate ID if applicable and a description/comment).  Separate output files are now created for a bedDetail and bigBed version of lab_associated_errors.  I added some markdown formatting to README.md.  I have tested the added instructions for running bedToBigBed and uploading custom tracks.
